### PR TITLE
DM-54870: Switch to lsst_cells_v2 skymap

### DIFF
--- a/bin.src/ci_lsstcam_run.py
+++ b/bin.src/ci_lsstcam_run.py
@@ -23,7 +23,7 @@ INSTRUMENT_NAME = "LSSTCam"
 QGRAPH_FILE = "DRP.qg"
 INPUTCOL = "LSSTCam/ci_m49,pretrained_models/tac_cnn_lsstcam_2026-02-26,skymaps"
 COLLECTION = f"{INSTRUMENT_NAME}/runs/ci_lsstcam"
-SKYMAP = "lsst_cells_v1"
+SKYMAP = "lsst_cells_v2"
 
 index_command = 0
 

--- a/configs/skymap.py
+++ b/configs/skymap.py
@@ -1,13 +1,14 @@
 # To be run with
 # butler register-skymap $REPO \
 # -C $OBS_LSST_DIR/config/makeSkyMap.py \
-# -c name="lsst_cells_v1"
+# -c name="lsst_cells_v2"
 
-config.name = "lsst_cells_v1"
+config.name = "lsst_cells_v2"
 config.skyMap.name = "rings"
 config.skyMap["rings"].numRings = 120
 config.skyMap["rings"].projection = "TAN"
 # Overlap between tracts (degrees)
 config.skyMap["rings"].tractOverlap = 1.0 / 60
 config.skyMap["rings"].pixelScale = 0.2
+config.skyMap["rings"].tractBuilder["cells"].cellBorder = 0
 config.skyMap["rings"].tractBuilder.name = "cells"

--- a/tests/test_hips_outputs.py
+++ b/tests/test_hips_outputs.py
@@ -34,7 +34,7 @@ class TestHipsOutputs(unittest.TestCase):
     """Check that HIPS outputs are as expected."""
     def setUp(self):
         self.butler = Butler(os.path.join(getPackageDir("ci_lsstcam"), "DATA"),
-                             instrument="LSSTCam", skymap="lsst_cells_v1",
+                             instrument="LSSTCam", skymap="lsst_cells_v2",
                              writeable=False, collections=["LSSTCam/runs/ci_lsstcam"])
         self._bands = ['u', 'g', 'r', 'i']
         self.hips_uri_base = ResourcePath(os.path.join(getPackageDir("ci_lsstcam"), "DATA", "hips"))


### PR DESCRIPTION
It makes sense to use `lsst_cells_v2` in `ci_lsstcam` since that is what we are using for DP2, and will continue to use until we finalize the skymap for DR1. In practice, this has little effect for anything in DRP pipelines currently, other than `metadetectionShear`.